### PR TITLE
Fix typo in repository's URL inside `printBugReport`

### DIFF
--- a/bin/elm-cli
+++ b/bin/elm-cli
@@ -183,7 +183,7 @@ OPTION:
 function printBugReport(msg) {
     console.error(`
 You found a bug!
-Please report at https://github.com:albertdahlin/elm-posix/issues
+Please report at https://github.com/albertdahlin/elm-posix/issues
 
 Copy the information below into the issue:
 


### PR DESCRIPTION
Hey,

I have encountered an error and I couldn't click on the link to file an issue as there is probably an typo. This PR fixes it. If it was not meant to be an typo, just close it.